### PR TITLE
Mesebox width and size are configurable

### DIFF
--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -1,0 +1,2 @@
+# Number of slots a single mesebox should have
+mesebox_box_size (Mesebox Number of Slots) int 24


### PR DESCRIPTION
# Meseboxes with Configurable Size

## Rational
- This allows, through configuration, the changing of the size of the meseboxes giving subgames and server worlds more freedom when balancing their worlds.
- In my specific case, I want both baskets and meseboxes to be available, but meseboxes to provide a lot more due to their cost

## Changes
 - Add setting mesebox_box_width
   - Represents width of the visible inventory.
   - Defaults to 8 (original default, drop-in safe)
   - Affects formspec used by all boxes
   - Available for game configs but omitted from settingtypes for safety
 - Add setting mesebox_box_size
   - Represents number of inventory slots a mesebox has
   - Defaults to 24 (drop-in safe);
   - Setting becomes Per-box, stored on first placement by setting the size of the inventory
   - Size of inventory is maintained based on the existing item list size as boxes convert from items to nodes and back
 - Mesebox formspec GUI now adjusts for different inventory widths and sizes.

## Testing
Recorded a test session and posted it to YouTube just to try out my OBS setup. It's here: https://youtu.be/4TxEKg78rgI
Note: Steps generally follow the outlined steps before. I did the testing twice.

### Steps
- Created a new game with existing mod unmodified
- Create set of boxes and fill them with stuff
- Reload the game with content from this branch using default settings (i sanitized my config before the run too)
- Validate boxes are the same as before
- Change setting to a smaller size (I chose 12)
- Reload game
- Validate existing boxes maintain their sizes
- Validate new boxes have the new size
- Change setting to unreasonable negative value (I chose -1; other test runs I've done -99; same behavior)
- Validate existing boxes maintain size when picked up and put down
- Validate new boxes have a size of 1
- Change setting to unreasonably high number (I chose 99999 or something like that)
- Validate existing boxes maintain size when picked up and put down
- Validate new boxes have a size of 50 (the clamped cap)